### PR TITLE
0801 cards meta field group

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Meta fields filters:
 ```
 //default values
 [
-	'none' => __( 'Ingen', 'savage-cards' ),
+	'none' => __( 'No tagline', 'savage-cards' ),
 	'auto' => __( 'Auto', 'savage-cards' ),
-	'manual' => __( 'Manuell', 'savage-cards' ),
+	'manual' => __( 'Manual', 'savage-cards' ),
 ]
 ```
 - `savage/card/meta/locations` - for adding locations to the ACF field group.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,39 @@
 # Savage
-
 Hogan + Savage = The Mega Powers!
 
-## TODO
+A plugin for setting up a card view for different content. Intended for use with [Hogan Grid](https://github.com/DekodeInteraktiv/hogan-grid).
+
+Also contains a custom post type for custom global cards.
+
+## Installation
+Install the module using Composer `composer require dekodeinteraktiv/savage-cards` or simply by downloading this repository and placing it in `wp-content/plugins`
+
+## Available filters
+Meta fields filters:
+- `savage/card/meta/image_types` - customize dropdown for card image options
+```
+//default values
+[
+	'featured' => __( 'Use featured image', 'savage-cards' ),
+	'alternative' => __( 'Use alternative image', 'savage-cards' ),
+	'none' => __( 'No image', 'savage-cards' ),
+]
+```
+- `savage/card/meta/tagline_types` - customize dropdown for card tagline types
+```
+//default values
+[
+	'none' => __( 'Ingen', 'savage-cards' ),
+	'auto' => __( 'Auto', 'savage-cards' ),
+	'manual' => __( 'Manuell', 'savage-cards' ),
+]
+```
+- `savage/card/meta/locations` - for adding locations to the ACF field group.
+- `savage/card/field_group/fields_before` - add new fields to group before existing fields.
+- `savage/card/field_group/fields_after` - add new fields to group after existing fields.
+
+Custom card filters
+- `savage/card/custom/content/tabs` - change tabs in custom card wysiwyg field.
+- `savage/card/custom/content/toolbar` - change toolbar custom card wysiwyg field.
+
+## Changelog

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -57,6 +57,9 @@ class Core {
 		// Load text domain on plugins_loaded.
 		add_action( 'plugins_loaded', [ $this, 'load_textdomain' ] );
 
+		// Register card field group.
+		add_action( 'acf/include_fields', [ $this, 'register_card_meta_field_group' ] );
+
 		// Register cards.
 		add_action( 'plugins_loaded', [ $this, 'register_cards' ] );
 
@@ -87,6 +90,171 @@ class Core {
 		load_plugin_textdomain( 'savage-cards', false, $this->dir . '/languages' );
 	}
 
+	/**
+	 * Register default field group for card meta.
+	 *
+	 * @return void
+	 */
+	public function register_card_meta_field_group() {
+
+		$fields_before = apply_filters( 'savage/card/field_group/fields_before', [] );
+		$fields_after = apply_filters( 'savage/card/field_group/fields_after', [] );
+
+		$meta_fields = [
+			[
+				'key' => 'savage_card_field_image_type',
+				'label' => __( 'Image on card', 'savage-cards' ),
+				'name' => 'savage_image_type',
+				'type' => 'select',
+				'required' => 0,
+				'choices' => apply_filters( 'savage/card/meta/image_types', [
+					'featured' => __( 'Use featured image', 'savage-cards' ),
+					'alternative' => __( 'Use alternative image', 'savage-cards' ),
+					'none' => __( 'No image', 'savage-cards' ),
+				] ),
+				'allow_null' => 0,
+				'multiple' => 0,
+				'ui' => 0,
+				'ajax' => 0,
+				'return_format' => 'value',
+			],
+			[
+				'key' => 'savage_card_field_image',
+				'label' => __( 'Alternative image:', 'savage-cards' ),
+				'name' => 'savage_image',
+				'type' => 'image',
+				'required' => 1,
+				'conditional_logic' => [
+					[
+						[
+							'field' => 'savage_card_field_image_type',
+							'operator' => '==',
+							'value' => 'alternative',
+						],
+					],
+				],
+				'return_format' => 'array',
+				'preview_size' => 'thumbnail',
+				'library' => 'all',
+				'min_width' => '',
+				'min_height' => '',
+				'min_size' => '',
+				'max_width' => '',
+				'max_height' => '',
+				'max_size' => '',
+				'mime_types' => '',
+			],
+			[
+				'key' => 'savage_card_field_title',
+				'label' => __( 'Override title', 'savage-cards' ),
+				'name' => 'savage_title',
+				'type' => 'text',
+				'instructions' => __( 'Leave empty to use post title', 'savage-cards' ),
+				'required' => 0,
+				'maxlength' => '',
+			],
+			[
+				'key' => 'savage_card_field_tagline_type',
+				'label' => __( 'Tagline', 'savage-cards' ),
+				'name' => 'savage_tagline',
+				'type' => 'select',
+				'required' => 0,
+				'choices' => apply_filters( 'savage/card/meta/tagline_types', [
+					'none' => __( 'Ingen', 'savage-cards' ),
+					'auto' => __( 'Auto', 'savage-cards' ),
+					'manual' => __( 'Manuell', 'savage-cards' ),
+				] ),
+				'allow_null' => 0,
+				'multiple' => 0,
+				'ui' => 0,
+				'ajax' => 0,
+				'return_format' => 'value',
+			],
+			[
+				'key' => 'savage_card_field_tagline_text',
+				'label' => '',
+				'name' => 'savage_tagline_text',
+				'type' => 'text',
+				//'instructions' => __( 'Max xx chars.', 'savage-cards' ),
+				'required' => 1,
+				'conditional_logic' => [
+					[
+						[
+							'field' => 'savage_card_field_tagline_type',
+							'operator' => '==',
+							'value' => 'manual',
+						],
+					],
+				],
+				'maxlength' => '',
+			],
+			[
+				'key' => 'savage_card_field_excerpt',
+				'label' => __( 'Excerpt', 'savage-cards' ),
+				'name' => 'savage_excerpt',
+				'type' => 'textarea',
+				'instructions' => __( 'Max xx chars.', 'savage-cards' ),
+				'required' => 0,
+				'maxlength' => '',
+				'rows' => 3,
+				'new_lines' => '',
+			],
+			[
+				'key' => 'savage_card_field_more_text',
+				'label' => __( 'Link text', 'savage-cards' ),
+				'name' => 'savage_link_title',
+				'type' => 'text',
+				'instructions' => __( '"Read more"-text', 'savage-cards' ),
+				'required' => 0,
+				'conditional_logic' => 0,
+				'maxlength' => '',
+			],
+		];
+
+		$location = [
+			[
+				[
+					'param'    => 'post_type',
+					'operator' => '==',
+					'value'    => 'post',
+				],
+			],
+			[
+				[
+					'param'    => 'post_type',
+					'operator' => '==',
+					'value'    => 'page',
+				],
+			],
+		];
+
+		$hide_on_screen = [
+			'the_content',
+			'custom_fields',
+			'discussion',
+			'comments',
+			'revisions',
+			'slug',
+			'author',
+			'format',
+			'tags',
+			'send-trackbacks',
+		];
+
+		// Include custom fields before and after flexible content field.
+		$field_group_fields = array_merge( $fields_before, $meta_fields, $fields_after );
+
+		acf_add_local_field_group(
+			[
+				'key'            => 'savage_card_meta_fields',
+				'title'          => __( 'Card content', 'savage-cards' ),
+				'fields'         => $field_group_fields,
+				'location' => apply_filters( 'savage/card/meta/locations', $location ),
+				'position' => 'side',
+				'hide_on_screen' => apply_filters( 'savage/card/field_group/hide_on_screen', $hide_on_screen ),
+			]
+		);
+	}
 	/**
 	 * Register cards from filter into core plugin.
 	 *

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -160,9 +160,9 @@ class Core {
 				'type' => 'select',
 				'required' => 0,
 				'choices' => apply_filters( 'savage/card/meta/tagline_types', [
-					'none' => __( 'Ingen', 'savage-cards' ),
+					'none' => __( 'No tagline', 'savage-cards' ),
 					'auto' => __( 'Auto', 'savage-cards' ),
-					'manual' => __( 'Manuell', 'savage-cards' ),
+					'manual' => __( 'Manual', 'savage-cards' ),
 				] ),
 				'allow_null' => 0,
 				'multiple' => 0,

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -241,7 +241,7 @@ class Core {
 			'send-trackbacks',
 		];
 
-		// Include custom fields before and after flexible content field.
+		// Include custom fields before and after default fields.
 		$field_group_fields = array_merge( $fields_before, $meta_fields, $fields_after );
 
 		acf_add_local_field_group(


### PR DESCRIPTION
Admin screenshot: https://d.pr/i/MbByCt

- "image on card" : options to not use image on card, use featured image, or use alternative image.
- fields for overriding title and excerpt text.
- tagline options: no tagline, manual, or auto. What auto is will be defined per post type per project, ex. term, taxonomy or post type.