### PR TITLE
Add extensions component

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Meta fields filters:
 - `savage/card/default_components` - default components used in the templates
 - `savage/card/components/savage_link/text` - link text
 - `savage/card/components/label/auto` - set rules for auto-label on cards
+- `savage/card/components/extensions` - add custom elements to default card after excerpt (text, date, btn etc.)
 
 Custom card filters
 - `savage/card/custom/bg_color_options` - filter for adding themes's color palette to card bg_color options.

--- a/components/extensions.php
+++ b/components/extensions.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Savage Component: Extensions
+ *
+ * @package Savage
+ */
+
+if ( ! isset( $args ) || ! is_array( $args ) ) {
+	return;
+}
+
+foreach ( $args as $value ) {
+	echo wp_kses_post( $value );
+}

--- a/includes/class-card.php
+++ b/includes/class-card.php
@@ -65,6 +65,7 @@ abstract class Card {
 				 * @hooked savage_card_label - 10
 				 * @hooked savage_card_heading - 20
 				 * @hooked savage_card_excerpt - 30
+				 * @hooked savage_card_extensions - 35
 				 */
 				do_action( 'savage/card/template/body/' . $this->name, $args );
 

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -115,6 +115,11 @@ class Core {
 					'callback' => 'savage_card_excerpt',
 					'priority' => 30,
 				],
+				'extensions' => [
+					'filter'   => 'body',
+					'callback' => 'savage_card_extensions',
+					'priority' => 35,
+				],
 				'link'    => [
 					'filter'   => 'footer',
 					'callback' => 'savage_card_link',

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -95,22 +95,22 @@ class Core {
 
 		$this->_components = (array) apply_filters(
 			'savage/card/default_components', [
-				'image'   => [
+				'image'      => [
 					'filter'   => 'header',
 					'callback' => 'savage_card_image',
 					'priority' => 10,
 				],
-				'label'   => [
+				'label'      => [
 					'filter'   => 'body',
 					'callback' => 'savage_card_label',
 					'priority' => 10,
 				],
-				'heading' => [
+				'heading'    => [
 					'filter'   => 'body',
 					'callback' => 'savage_card_heading',
 					'priority' => 20,
 				],
-				'excerpt' => [
+				'excerpt'    => [
 					'filter'   => 'body',
 					'callback' => 'savage_card_excerpt',
 					'priority' => 30,
@@ -120,7 +120,7 @@ class Core {
 					'callback' => 'savage_card_extensions',
 					'priority' => 35,
 				],
-				'link'    => [
+				'link'       => [
 					'filter'   => 'footer',
 					'callback' => 'savage_card_link',
 					'priority' => 10,

--- a/includes/class-defaultcard.php
+++ b/includes/class-defaultcard.php
@@ -29,6 +29,7 @@ if ( ! class_exists( '\\Dekode\\Savage\\DefaultCard' ) && class_exists( '\\Dekod
 				'label',
 				'heading',
 				'excerpt',
+				'extensions',
 				'link',
 			];
 

--- a/includes/component-functions.php
+++ b/includes/component-functions.php
@@ -105,6 +105,25 @@ if ( ! function_exists( 'savage_card_excerpt' ) ) {
 	}
 }
 
+if ( ! function_exists( 'savage_card_extensions' ) ) {
+	/**
+	 * Additional fields for default card.
+	 *
+	 * @param array $args Component args.
+	 */
+	function savage_card_extensions( $args ) {
+
+		$additional_fields = apply_filters( 'savage/card/components/extensions', [], $args );
+
+		if ( ! empty( $additional_fields ) ) {
+
+			foreach ( $additional_fields as $extension ) {
+				savage_card_component( 'extensions', [ $extension ] );
+			}
+		}
+	}
+}
+
 if ( ! function_exists( 'savage_card_link' ) ) {
 	/**
 	 * Link


### PR DESCRIPTION
Denne PR'en legger til en extensions-komponent i default kort for å ha mulighet til å variere felter som kommer etter excerpt på kort. 

F.eks på Nasjonalbibliteket:
![screen shot 2018-02-05 at 15 34 57](https://user-images.githubusercontent.com/6534936/35809882-3f9666ea-0a8a-11e8-9e40-22ab8aa2105a.png)

Fra rammeverket:
![screen shot 2018-02-05 at 15 38 07](https://user-images.githubusercontent.com/6534936/35810011-98b47b18-0a8a-11e8-8325-3b1dba93f0bb.png)

Tenker at noen extension-felter som går igjen på flere prosjekter kan ligge som partials og dras inn via filter, men vil gjerne ha input på om dette er en fornuftig måte å customisere kort på før jeg fortsetter. 