### PR TITLE
Add linkteaser component

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Meta fields filters:
 - `savage/card/default_card_post_types` - post types that should have the default card
 - `savage/card/default_card` - default card type
 - `savage/card/default_components` - default components used in the templates
-- `savage/card/components/savage_link/text` - link text
+- `savage/card/components/savage_link/text` - link text for screenreaders
+- `savage/card/components/savage_link/teaser` - link text (or button) on card
 - `savage/card/components/label/auto` - set rules for auto-label on cards
 
 Custom card filters

--- a/components/linkteaser.php
+++ b/components/linkteaser.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Savage Component: Link teaser text
+ *
+ * @package Savage
+ */
+
+if ( ! isset( $args ) || ! is_array( $args ) ) {
+	return;
+}
+
+$defaults = [
+	'teasertext' => '',
+];
+
+$args = wp_parse_args( $args, $defaults );
+
+// Return early if text isn't defined.
+if ( empty( $args['teasertext'] ) ) {
+	return;
+}
+
+// Add card classname.
+savage_card_add_classname( 'savage-has-teaser' );
+
+printf( '<p class="savage-card-teaser">%s</p>',
+	wp_kses_post( $args['teasertext'] )
+);

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -95,27 +95,32 @@ class Core {
 
 		$this->_components = (array) apply_filters(
 			'savage/card/default_components', [
-				'image'   => [
+				'image'      => [
 					'filter'   => 'header',
 					'callback' => 'savage_card_image',
 					'priority' => 10,
 				],
-				'label'   => [
+				'label'      => [
 					'filter'   => 'body',
 					'callback' => 'savage_card_label',
 					'priority' => 10,
 				],
-				'heading' => [
+				'heading'    => [
 					'filter'   => 'body',
 					'callback' => 'savage_card_heading',
 					'priority' => 20,
 				],
-				'excerpt' => [
+				'excerpt'    => [
 					'filter'   => 'body',
 					'callback' => 'savage_card_excerpt',
 					'priority' => 30,
 				],
-				'link'    => [
+				'linkteaser' => [
+					'filter'   => 'body',
+					'callback' => 'savage_card_linkteaser',
+					'priority' => 40,
+				],
+				'link'       => [
 					'filter'   => 'footer',
 					'callback' => 'savage_card_link',
 					'priority' => 10,

--- a/includes/class-defaultcard.php
+++ b/includes/class-defaultcard.php
@@ -29,6 +29,7 @@ if ( ! class_exists( '\\Dekode\\Savage\\DefaultCard' ) && class_exists( '\\Dekod
 				'label',
 				'heading',
 				'excerpt',
+				'linkteaser',
 				'link',
 			];
 

--- a/includes/component-functions.php
+++ b/includes/component-functions.php
@@ -124,3 +124,20 @@ if ( ! function_exists( 'savage_card_link' ) ) {
 		] );
 	}
 }
+
+if ( ! function_exists( 'savage_card_linkteaser' ) ) {
+	/**
+	 * Link teaser text
+	 *
+	 * @param array $args Component args.
+	 */
+	function savage_card_linkteaser( $args ) {
+		$savage_teaser = apply_filters( 'savage/card/components/savage_link/teaser', get_post_meta( $args['id'], 'savage_link_title', true ), $args );
+
+		if ( ! empty( $savage_teaser ) ) {
+			savage_card_component( 'linkteaser', [
+				'teasertext' => $savage_teaser,
+			] );
+		}
+	}
+}


### PR DESCRIPTION
Enkel komponent for å vise lenketekst fra savage meta fields, med filter for å overstyre lenketekst (brukes f.eks på NB, hvor en av post typene skal ha en default lenketekst om det ikke er satt i Card meta for posten)

Tar gjerne input om det er noe mer som må til for å kunne feks stile teksten som en knapp, legge på pil etter teksten etc.