### PR TITLE
Allow themes to register new cards

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -61,7 +61,7 @@ class Core {
 		add_action( 'acf/include_fields', [ $this, 'register_card_meta_field_group' ] );
 
 		// Register cards (need to be after plugins/themes has applied savage card filter).
-		add_action( 'plugins_loaded', [ $this, 'register_cards' ], 50 );
+		add_action( 'after_setup_theme', [ $this, 'register_cards' ] );
 
 		add_action( 'savage/register_cards', [ $this, 'register_core_cards' ] );
 	}


### PR DESCRIPTION
Switch from `plugins_loaded` action to `after_setup_theme` action because the `plugins_loaded` action is runned before `functions.php` is loaded. To allow themes to register custom cards in the `functions.php` file we need to register the cards in savage after the themes has added their cards.