### PR TITLE
Don’t require a layout for simple custom card. Use card meta fields…

### DIFF
--- a/includes/class-customcard.php
+++ b/includes/class-customcard.php
@@ -130,7 +130,7 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 							'name'         => 'card_content_flex',
 							'type'         => 'flexible_content',
 							'instructions' => '',
-							'required'     => 1,
+							'required'     => 0,
 							'layouts'      => [
 								[
 									'key'        => $this->field_key . '_flex_standard',
@@ -185,7 +185,7 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 								],
 							],
 							'button_label' => __( 'Select a card type', 'savage-cards' ),
-							'min'          => 1,
+							'min'          => 0,
 							'max'          => 1,
 						],
 					],


### PR DESCRIPTION
… instead with default card.

(for superenkle manuelle kort trenger vi ikke ha egne kort, de kan bruke defaultkortet)