### PR TITLE
Custom card image size

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Custom card filters
 
 ## Changelog
 
+### 1.0.5
+- Use `medium_large` image size as default for all cards.
+- Add filter `savage/card/components/image/size` for setting custom image size.
+
 ### 1.0.4
 - Added `Icon` component.
 - Added `Avatar` component.

--- a/includes/component-functions.php
+++ b/includes/component-functions.php
@@ -13,7 +13,9 @@ if ( ! function_exists( 'savage_card_image' ) ) {
 	 */
 	function savage_card_image( $args ) {
 		$image_type = (string) get_post_meta( $args['id'], 'savage_image_type', true );
-		$image_size = apply_filters( 'savage/card/components/image/size', 'medium_large' );
+
+		$default_image_size = 'full' === $args['size'] ? 'large' : 'medium_large';
+		$image_size = apply_filters( 'savage/card/components/image/size', $default_image_size, $args );
 
 		switch ( $image_type ) {
 			case 'none':

--- a/includes/component-functions.php
+++ b/includes/component-functions.php
@@ -15,7 +15,7 @@ if ( ! function_exists( 'savage_card_image' ) ) {
 		$image_type = (string) get_post_meta( $args['id'], 'savage_image_type', true );
 
 		$default_image_size = 'full' === $args['size'] ? 'large' : 'medium_large';
-		$image_size = apply_filters( 'savage/card/components/image/size', $default_image_size, $args );
+		$image_size         = apply_filters( 'savage/card/components/image/size', $default_image_size, $args );
 
 		switch ( $image_type ) {
 			case 'none':

--- a/includes/component-functions.php
+++ b/includes/component-functions.php
@@ -13,6 +13,7 @@ if ( ! function_exists( 'savage_card_image' ) ) {
 	 */
 	function savage_card_image( $args ) {
 		$image_type = (string) get_post_meta( $args['id'], 'savage_image_type', true );
+		$image_size = apply_filters( 'savage/card/components/image/size', 'medium_large' );
 
 		switch ( $image_type ) {
 			case 'none':
@@ -21,11 +22,16 @@ if ( ! function_exists( 'savage_card_image' ) ) {
 
 			case 'alternative':
 				$image_id = get_post_meta( $args['id'], 'savage_image', true );
-				$url      = wp_get_attachment_url( $image_id );
-				break;
+				$image    = wp_get_attachment_image_src( $image_id, $image_size );
 
+				if ( is_array( $image ) && ! empty( $image ) ) {
+					$url = $image[0];
+				} else {
+					$url = wp_get_attachment_url( $image_id ); // Default image as fallback.
+				}
+				break;
 			default:
-				$url = get_the_post_thumbnail_url( $args['id'] );
+				$url = get_the_post_thumbnail_url( $args['id'], $image_size );
 				break;
 		}
 

--- a/savage-cards.php
+++ b/savage-cards.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/dekodeinteraktiv/savage-cards
  * GitHub Plugin URI: https://github.com/dekodeinteraktiv/savage-cards
  * Description: Card setup plugin
- * Version: 1.0.4
+ * Version: 1.0.5
  * Author: Dekode
  * Author URI: https://dekode.no
  * License: GPL-3.0-or-later


### PR DESCRIPTION
- Use `medium_large` image size as default for all cards. (_instead of original size_)
- Add filter `savage/card/components/image/size` for setting custom image size.