### PR TITLE
Bugfix: double link added to card

### DIFF
--- a/includes/class-card.php
+++ b/includes/class-card.php
@@ -50,6 +50,7 @@ abstract class Card {
 		do_action( 'savage/card/template/init', $this->name );
 
 		ob_start();
+
 		/*
 		 * @hooked savage_card_image - 10
 		 */

--- a/includes/class-card.php
+++ b/includes/class-card.php
@@ -50,11 +50,11 @@ abstract class Card {
 		do_action( 'savage/card/template/init', $this->name );
 
 		ob_start();
-
 		/*
 		 * @hooked savage_card_image - 10
 		 */
 		do_action( 'savage/card/template/header/' . $this->name, $args );
+		do_action( 'savage/card/template/header/' . $this->name . '/' . $args['id'], $args );
 
 		?>
 		<div class="savage-card-body">
@@ -69,7 +69,7 @@ abstract class Card {
 				 * @hooked savage_card_linkteaser - 50
 				 */
 				do_action( 'savage/card/template/body/' . $this->name, $args );
-
+				do_action( 'savage/card/template/body/' . $this->name . '/' . $args['id'], $args );
 				?>
 			</div>
 		</div>

--- a/includes/class-customcard.php
+++ b/includes/class-customcard.php
@@ -32,13 +32,6 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 		 * Card constructor.
 		 */
 		public function __construct() {
-			$this->components = [
-				'image',
-				'body-header',
-				'label',
-				'heading',
-				'excerpt',
-			];
 
 			$this->post_type = 'savage_custom_card';
 			$this->register_card_post_type();
@@ -256,15 +249,17 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 
 			remove_action( 'savage/card/template/header/savage_custom_card', 'savage_card_image', 10 );
 			remove_action( 'savage/card/template/body/savage_custom_card', ' savage_card_body_header', 10 );
+			remove_action( 'savage/card/template/body/savage_custom_card', ' savage_card_label', 20 );
 			remove_action( 'savage/card/template/body/savage_custom_card', 'savage_card_heading', 30 );
 			remove_action( 'savage/card/template/body/savage_custom_card', 'savage_card_excerpt', 40 );
 			remove_action( 'savage/card/template/body/savage_custom_card', 'savage_card_linkteaser', 50 );
 
 			$layouts = get_field( 'card_content_flex', $args['id'] );
 			if ( empty( $layouts ) ) {
-				add_action( 'savage/card/template/body/savage_custom_card/' . $args['id'], 'savage_card_body_header', 10 );
 				add_action( 'savage/card/template/header/savage_custom_card/' . $args['id'], 'savage_card_image', 10 );
+				add_action( 'savage/card/template/body/savage_custom_card/' . $args['id'], 'savage_card_body_header', 10 );
 				add_action( 'savage/card/template/body/savage_custom_card/' . $args['id'], 'savage_card_heading', 30 );
+				add_action( 'savage/card/template/body/savage_custom_card/' . $args['id'], 'savage_card_label', 20 );
 				add_action( 'savage/card/template/body/savage_custom_card/' . $args['id'], 'savage_card_excerpt', 40 );
 				add_action( 'savage/card/template/body/savage_custom_card/' . $args['id'], 'savage_card_linkteaser', 50 );
 			}

--- a/includes/class-customcard.php
+++ b/includes/class-customcard.php
@@ -38,7 +38,6 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 				'label',
 				'heading',
 				'excerpt',
-			// 'linkteaser',
 			];
 
 			$this->post_type = 'savage_custom_card';

--- a/includes/class-customcard.php
+++ b/includes/class-customcard.php
@@ -240,7 +240,11 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 			if ( ! empty( $link ) && empty( $link['title'] ) ) {
 				savage_card_component( 'link', $link );
 			} else {
-				printf( '<a href="%1$s" target="%2$s" class="savage-card-teaser">%3$s</a>', $link['url'], $link['target'], $link['title'] );
+				printf( '<a href="%s" class="savage-card-teaser"%s>%s</a>',
+					esc_url( $link['url'] ),
+					! empty( $link['target'] ) ? sprintf( ' target="%s"', esc_attr( $link['target'] ) ) : '',
+					esc_html( $link['title'] )
+				);
 			}
 		}
 

--- a/includes/class-customcard.php
+++ b/includes/class-customcard.php
@@ -6,6 +6,7 @@
  */
 
 declare( strict_types = 1 );
+
 namespace Dekode\Savage;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -37,7 +38,7 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 				'label',
 				'heading',
 				'excerpt',
-				'linkteaser',
+			//              'linkteaser',
 			];
 
 			$this->post_type = 'savage_custom_card';
@@ -182,9 +183,10 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 		 * Add custom toolbars
 		 *
 		 * @param array $toolbars Current Toolbars.
+		 *
 		 * @return array $toolbars Array with new toolbars.
 		 */
-		public function append_card_toolbar( array $toolbars ) : array {
+		public function append_card_toolbar( array $toolbars ): array  {
 
 			$toolbars['savage_card_toolbar'] = [
 				1 => [
@@ -203,6 +205,7 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 					'redo',
 				],
 			];
+
 			return $toolbars;
 		}
 
@@ -213,11 +216,8 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 		 */
 		public function template_content( $args ) {
 
-			$layout_content = '';
-			$layouts        = get_field( 'card_content_flex', $args['id'] );
-
+			$layouts = get_field( 'card_content_flex', $args['id'] );
 			if ( ! empty( $layouts ) ) {
-
 				// Only one layout possible on a card.
 				$active_layout = reset( $layouts );
 				do_action( 'savage/card/custom/body/layout_content', $active_layout );
@@ -234,11 +234,35 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 		 * @param array $args Component args.
 		 */
 		public function template_link( $args ) {
+
 			$link = get_post_meta( $args['id'], 'card_link', true );
 
-			if ( ! empty( $link ) ) {
+			if ( ! empty( $link ) && empty( $link['title'] ) ) {
 				savage_card_component( 'link', $link );
+			} else {
+				printf( '<a href="%1$s" target="%2$s" class="savage-card-teaser">%3$s</a>', $link['url'], $link['target'], $link['title'] );
 			}
 		}
+
+		public function get_markup( array $args = [] ) {
+
+			remove_action( 'savage/card/template/header/savage_custom_card', 'savage_card_image', 10 );
+			remove_action( 'savage/card/template/body/savage_custom_card', ' savage_card_body_header', 10 );
+			remove_action( 'savage/card/template/body/savage_custom_card', 'savage_card_heading', 30 );
+			remove_action( 'savage/card/template/body/savage_custom_card', 'savage_card_excerpt', 40 );
+			remove_action( 'savage/card/template/body/savage_custom_card', 'savage_card_linkteaser', 50 );
+
+			$layouts = get_field( 'card_content_flex', $args['id'] );
+			if ( empty( $layouts ) ) {
+				add_action( 'savage/card/template/body/savage_custom_card/' . $args['id'], 'savage_card_body_header', 10 );
+				add_action( 'savage/card/template/header/savage_custom_card/' . $args['id'], 'savage_card_image', 10 );
+				add_action( 'savage/card/template/body/savage_custom_card/' . $args['id'], 'savage_card_heading', 30 );
+				add_action( 'savage/card/template/body/savage_custom_card/' . $args['id'], 'savage_card_excerpt', 40 );
+				add_action( 'savage/card/template/body/savage_custom_card/' . $args['id'], 'savage_card_linkteaser', 50 );
+			}
+
+			return parent::get_markup( $args );
+		}
+
 	}
 }

--- a/includes/class-customcard.php
+++ b/includes/class-customcard.php
@@ -186,7 +186,7 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 		 *
 		 * @return array $toolbars Array with new toolbars.
 		 */
-		public function append_card_toolbar( array $toolbars ): array  {
+		public function append_card_toolbar( array $toolbars ) : array {
 
 			$toolbars['savage_card_toolbar'] = [
 				1 => [

--- a/includes/class-customcard.php
+++ b/includes/class-customcard.php
@@ -38,7 +38,7 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 				'label',
 				'heading',
 				'excerpt',
-			//              'linkteaser',
+			// 'linkteaser',
 			];
 
 			$this->post_type = 'savage_custom_card';
@@ -244,6 +244,11 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 			}
 		}
 
+		/**
+		 * Get card markup
+		 *
+		 * @param array $args Card option.
+		 */
 		public function get_markup( array $args = [] ) {
 
 			remove_action( 'savage/card/template/header/savage_custom_card', 'savage_card_image', 10 );

--- a/includes/class-customcard.php
+++ b/includes/class-customcard.php
@@ -217,9 +217,9 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 			$layouts        = get_field( 'card_content_flex', $args['id'] );
 
 			if ( ! empty( $layouts ) ) {
+
 				// Only one layout possible on a card.
 				$active_layout = reset( $layouts );
-				remove_all_actions( 'savage/card/template/body/' . $this->post_type );
 				do_action( 'savage/card/custom/body/layout_content', $active_layout );
 
 				if ( 'card_content' === $active_layout['acf_fc_layout'] ) {

--- a/includes/class-customcard.php
+++ b/includes/class-customcard.php
@@ -38,7 +38,6 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 				'heading',
 				'excerpt',
 				'linkteaser',
-				'link',
 			];
 
 			$this->post_type = 'savage_custom_card';
@@ -220,11 +219,10 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 			if ( ! empty( $layouts ) ) {
 				// Only one layout possible on a card.
 				$active_layout = reset( $layouts );
-
+				remove_all_actions( 'savage/card/template/body/' . $this->post_type );
 				do_action( 'savage/card/custom/body/layout_content', $active_layout );
 
 				if ( 'card_content' === $active_layout['acf_fc_layout'] ) {
-					remove_all_actions( 'savage/card/template/body/' . $this->post_type );
 					echo wp_kses_post( $active_layout['content'] );
 				}
 			}


### PR DESCRIPTION
Dersom det er lagt til en flex-layout på en manuelt kort skal savage-card-body være innholdet fra layouten. 

Hvis det ikke er lagt inn en layout vil jeg at det manuelle kortet skal bruke savage-card-components på samme måte som på default kort, men komponentene kommer ikke med på det manuelle kortet nå. Eks her: https://framework-demo.dev02.dekodes.no/grid/

Jeg sitter fast på hva det er jeg mangler for at komponentene skal vises, help?