### PR TITLE
Add menu order to field group

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -308,6 +308,7 @@ class Core {
 				'fields'         => $field_group_fields,
 				'location'       => apply_filters( 'savage/card/meta/locations', $location ),
 				'position'       => 'side',
+				'menu_order'     => 99,
 				'hide_on_screen' => apply_filters( 'savage/card/field_group/hide_on_screen', [] ),
 			]
 		);


### PR DESCRIPTION
When multiple field groups appear on an edit screen, the first field group's hide on screen options will be used (the one with the lowest order number).

Lets add a high number on savage because we want other plugins/themes option to have higher priority.