### PR TITLE
Add class for background color on custom card

### DIFF
--- a/includes/class-customcard.php
+++ b/includes/class-customcard.php
@@ -129,7 +129,7 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 							'conditional_logic' => 0,
 							'choices'           => apply_filters(
 								'savage/card/custom/bg_color_options', [
-									'bg_default' => __( 'Default', 'savage-cards' ),
+									'default' => __( 'Default', 'savage-cards' ),
 								]
 							),
 							'default_value'     => [],
@@ -233,6 +233,12 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 		public function template_header( array $args ) {
 			if ( ! $this->has_custom_content( $args['id'] ) ) {
 				do_action( 'savage/card/template/header/custom_card_default', $args );
+			}
+
+			$bg_color = get_post_meta( $args['id'], 'card_background', true );
+			if ( ! empty( $bg_color ) ) {
+				savage_card_add_classname( 'savage-has-background' );
+				savage_card_add_classname( $bg_color );
 			}
 		}
 

--- a/includes/class-customcard.php
+++ b/includes/class-customcard.php
@@ -238,7 +238,7 @@ if ( ! class_exists( '\\Dekode\\Savage\\CustomCard' ) && class_exists( '\\Dekode
 			$bg_color = get_post_meta( $args['id'], 'card_background', true );
 			if ( ! empty( $bg_color ) ) {
 				savage_card_add_classname( 'savage-has-background' );
-				savage_card_add_classname( $bg_color );
+				savage_card_add_classname( 'savage-bg-' . $bg_color );
 			}
 		}
 

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -75,7 +75,7 @@ function savage_get_card( array $args = [] ) : array {
  * @param string $classname Classname.
  */
 function savage_card_add_classname( string $classname ) {
-	\Dekode\Savage\Classnames::get_instance()->add_classname( $classname );
+	\Dekode\Savage\Classnames::get_instance()->add_classname( sanitize_html_class( $classname ) );
 }
 
 /**


### PR DESCRIPTION
Adds class 'savage-has-background' and class with value (ex. blue) from color options defined via filter 'savage/card/custom/bg_color_options'.

