### PR TITLE
Remove required constraint from alternative image

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -186,7 +186,7 @@ class Core {
 				'label'             => __( 'Alternative image:', 'savage-cards' ),
 				'name'              => 'savage_image',
 				'type'              => 'image',
-				'required'          => 1,
+				'required'          => 0,
 				'conditional_logic' => [
 					[
 						[


### PR DESCRIPTION
Fix so that card meta fields can be used with Gutenberg. Conditionals don't work, will have to look into that in separate issue.