### PR TITLE
Add filter to image url for featured image

### DIFF
--- a/includes/component-functions.php
+++ b/includes/component-functions.php
@@ -33,7 +33,7 @@ if ( ! function_exists( 'savage_card_image' ) ) {
 				}
 				break;
 			default:
-				$url = get_the_post_thumbnail_url( $args['id'], $image_size );
+				$url = apply_filters( 'savage/card/components/image/url', get_the_post_thumbnail_url( $args['id'], $image_size ) );
 				break;
 		}
 


### PR DESCRIPTION
For setting a fallback image fex:
```
add_filter( 'savage/card/components/image/url', 'set_fallback_image', 1, 9 );
function set_fallback_image( $url ) {
	if ( empty( $url ) ) {
		$url = get_template_directory_uri() . '/src/images/card-fallback.png';
	}
	return $url;
}