### PR TITLE
Add a wrapper around label

### DIFF
--- a/components/label.php
+++ b/components/label.php
@@ -24,6 +24,6 @@ if ( empty( $args['label'] ) ) {
 savage_card_add_classname( 'savage-has-label' );
 
 printf(
-	'<p class="savage-card-label">%s</p>',
+	'<div class="savage-card-label-holder"><p class="savage-card-label">%s</p></div>',
 	esc_html( $args['label'] )
 );


### PR DESCRIPTION
To make it easier to absolute position the label (so all headings line up) we need a wrapper around the label text